### PR TITLE
Fix: replace withOpacity with withValues in inventory badges

### DIFF
--- a/lib/screens/level3_inventory_screen.dart
+++ b/lib/screens/level3_inventory_screen.dart
@@ -429,8 +429,8 @@ class _StockBadge extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(20),
-        color: color.withOpacity(.12),
-        border: Border.all(color: color.withOpacity(.35)),
+        color: color.withValues(alpha: 0.12),
+        border: Border.all(color: color.withValues(alpha: 0.35)),
       ),
       child: Text('$value',
           style: TextStyle(fontWeight: FontWeight.w700, color: color)),
@@ -455,8 +455,8 @@ class _StatePill extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(20),
-        color: color.withOpacity(.12),
-        border: Border.all(color: color.withOpacity(.35)),
+        color: color.withValues(alpha: 0.12),
+        border: Border.all(color: color.withValues(alpha: 0.35)),
       ),
       child: Text(text,
           style: TextStyle(fontWeight: FontWeight.w700, color: color)),


### PR DESCRIPTION
## Summary
- replace the inventory badge decoration to use `withValues` instead of `withOpacity` to comply with Flutter 3.22+ recommendations

## Testing
- `flutter pub get` *(fails: Flutter SDK is not available in the container environment)*
- `flutter analyze` *(fails: Flutter SDK is not available in the container environment)*
- `flutter build web --release` *(fails: Flutter SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb35c899483329b509ecb964702bb