### PR TITLE
Add inline documentation and fix favicon path

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -54,6 +54,7 @@ class HomeDesktop extends StatelessWidget {
       body: SafeArea(
         child: LayoutBuilder(
           builder: (context, c) {
+            // Consideramos mobile si el ancho disponible es menor a 720 px.
             final isMobile = c.maxWidth < 720;
             return Center(
               child: ConstrainedBox(
@@ -61,20 +62,21 @@ class HomeDesktop extends StatelessWidget {
                 child: SingleChildScrollView(
                   padding: const EdgeInsets.all(16),
                   child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Hero
-                    Container(
-                      decoration: BoxDecoration(
-                          color: accent,
-                          borderRadius: BorderRadius.circular(20)),
-                      padding: const EdgeInsets.all(22),
-                      child: Builder(builder: (context) {
-                        final left = Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              const Text('👋 Hola, soy Marilú',
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Hero
+                      Container(
+                        decoration: BoxDecoration(
+                            color: accent,
+                            borderRadius: BorderRadius.circular(20)),
+                        padding: const EdgeInsets.all(22),
+                        child: Builder(builder: (context) {
+                          // Hero combinado: texto a la izquierda y personaje a la derecha.
+                          final left = Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const Text('👋 Hola, soy Marilú',
                                   style: TextStyle(
                                       fontSize: 40,
                                       fontWeight: FontWeight.w900,
@@ -141,6 +143,7 @@ class HomeDesktop extends StatelessWidget {
                       }),
                     ),
                     const SizedBox(height: 14),
+                    // Acciones principales debajo del hero.
                     Wrap(
                       spacing: 12,
                       runSpacing: 12,
@@ -263,6 +266,7 @@ class HomeDesktop extends StatelessWidget {
                     // Niveles
                     const _H3('🎮 Niveles'),
                     const SizedBox(height: 10),
+                    // Tarjetas con accesos a cada nivel gamificado.
                     Wrap(
                       spacing: 14,
                       runSpacing: 14,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,7 +19,9 @@ import 'state/orders_state.dart';
 import 'theme/kawaii_theme.dart';
 
 void main() {
+  // Asegura que el motor de Flutter esté listo antes de usar canales nativos.
   WidgetsFlutterBinding.ensureInitialized();
+  // Redirigimos los errores globales para imprimirlos en consola con stacktrace.
   FlutterError.onError = (details) {
     FlutterError.presentError(details);
     debugPrint('FLUTTER ERROR: ${details.exceptionAsString()}');
@@ -28,6 +30,7 @@ void main() {
     }
   };
   if (kIsWeb) {
+    // Usa rutas limpias sin hash cuando se ejecuta en navegador.
     setUrlStrategy(PathUrlStrategy());
   }
   runApp(const MyApp());
@@ -46,13 +49,16 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+    // Pre-cargamos los servicios y estado global antes de construir la UI.
     _initFuture = _loadDependencies();
   }
 
   Future<_AppDependencies> _loadDependencies() async {
+    // Configura el locale por defecto para formatos y fechas.
     Intl.defaultLocale = 'es_AR';
     final seed = await DataService.loadInventory();
 
+    // Estados compartidos que se inyectarán con Provider.
     final appState = AppState()..initInventory(seed);
     final ordersState = OrdersState();
     await ordersState.load();
@@ -72,6 +78,7 @@ class _MyAppState extends State<MyApp> {
       future: _initFuture,
       builder: (context, snapshot) {
         if (snapshot.connectionState != ConnectionState.done) {
+          // Splash mínimo mientras se inicializa la aplicación.
           return const MaterialApp(
             debugShowCheckedModeBanner: false,
             home: Scaffold(
@@ -82,6 +89,7 @@ class _MyAppState extends State<MyApp> {
         }
 
         if (snapshot.hasError) {
+          // Mensaje de error amigable si falló la carga inicial.
           return MaterialApp(
             debugShowCheckedModeBanner: false,
             home: Scaffold(
@@ -101,6 +109,7 @@ class _MyAppState extends State<MyApp> {
         }
 
         final deps = snapshot.data!;
+        // Inyectamos los estados compartidos en el árbol de widgets.
         return MultiProvider(
           providers: [
             ChangeNotifierProvider.value(value: deps.appState),
@@ -157,6 +166,7 @@ class MariluApp extends StatelessWidget {
       ],
       builder: (context, child) {
         final media = MediaQuery.of(context);
+        // Limita la escala de texto del sistema para preservar el diseño.
         return MediaQuery(
           data: media.copyWith(
             textScaler:
@@ -166,6 +176,7 @@ class MariluApp extends StatelessWidget {
         );
       },
       title: 'Marilu - Ciencia de Datos',
+      // Evita el efecto glow de scroll en web/desktop.
       scrollBehavior: const _NoGlowScrollBehavior(),
       theme: KawaiiTheme.materialTheme(),
       initialRoute: '/',
@@ -194,6 +205,7 @@ class _NoGlowScrollBehavior extends ScrollBehavior {
     Widget child,
     ScrollableDetails details,
   ) {
+    // Devuelve el child directamente para eliminar la animación por defecto.
     return child;
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,8 @@
     <base href="/" />
     <title>Marilú Portfolio</title>
     <link rel="manifest" href="manifest.json" />
-    <link rel="icon" type="image/png" href="assets/icons/favicon.png" />
+    <!-- El favicon debe apuntar al archivo en la carpeta web raíz -->
+    <link rel="icon" type="image/png" href="favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Summary
- add contextual comments to the app bootstrap in `main.dart` and the responsive home layout so the flow is easier to follow
- document the level 1 game screen to explain timers, scoring and A/B tracking logic
- fix the web favicon link so the browser loads the bundled icon from the `web/` root

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cecadd9fc0833290c85f558b835537