### PR TITLE
Replace deprecated withOpacity usage and handle nullable overlays

### DIFF
--- a/lib/screens/level3_inventory_screen.dart
+++ b/lib/screens/level3_inventory_screen.dart
@@ -123,7 +123,7 @@ class _Level3InventoryScreenState extends State<Level3InventoryScreen> {
       DataCell(Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
         decoration: BoxDecoration(
-          color: color.withOpacity(0.15),
+          color: color.withValues(alpha: 0.15),
           borderRadius: BorderRadius.circular(20),
         ),
         child: Text(
@@ -202,7 +202,7 @@ class _Level3InventoryScreenState extends State<Level3InventoryScreen> {
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                 decoration: BoxDecoration(
-                  color: color.withOpacity(0.15),
+                  color: color.withValues(alpha: 0.15),
                   borderRadius: BorderRadius.circular(20),
                 ),
                 child: Text(
@@ -426,8 +426,8 @@ class _StockBadge extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(20),
-        color: color.withOpacity(0.15),
-        border: Border.all(color: color.withOpacity(0.35)),
+        color: color.withValues(alpha: 0.15),
+        border: Border.all(color: color.withValues(alpha: 0.35)),
       ),
       child: Text('$value',
           style: TextStyle(fontWeight: FontWeight.w700, color: color)),

--- a/lib/utils/kawaii_toast.dart
+++ b/lib/utils/kawaii_toast.dart
@@ -11,7 +11,7 @@ class KawaiiToast {
     Duration duration = const Duration(milliseconds: 1600),
     bool success = true,
   }) {
-    final overlay = Overlay.of(context);
+    final overlay = Overlay.maybeOf(context);
     if (overlay == null) return;
 
     final entry = OverlayEntry(
@@ -31,7 +31,7 @@ class KawaiiToast {
                   borderRadius: BorderRadius.circular(12),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withOpacity(.12),
+                      color: Colors.black.withValues(alpha: .12),
                       blurRadius: 10,
                       offset: const Offset(0, 4),
                     ),


### PR DESCRIPTION
## Summary
- replace remaining usages of `withOpacity` with the new `withValues(alpha: …)` helper across the inventory screen and toast overlay shadow
- switch the toast overlay lookup to `Overlay.maybeOf` so the explicit null check remains meaningful

## Testing
- not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ced0c300a88332ae5dd1a9d0150062