### PR TITLE
Improve inventory, gameplay flow, and icons

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -24,6 +24,50 @@ class HomeDesktop extends StatelessWidget {
     }
   }
 
+  void _openDashboardModal(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      useSafeArea: true,
+      builder: (ctx) => Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Elegí qué querés analizar',
+              style: TextStyle(
+                fontWeight: FontWeight.w800,
+                color: onAccent,
+              ),
+            ),
+            const SizedBox(height: 12),
+            ListTile(
+              leading: const Icon(Icons.space_dashboard_rounded,
+                  color: onAccent),
+              title: const Text('Ver Dashboard'),
+              subtitle: const Text('KPIs, participación y evolución del juego'),
+              onTap: () {
+                Navigator.pop(ctx);
+                Navigator.pushNamed(context, '/dashboard');
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.science, color: onAccent),
+              title: const Text('Experimento A/B'),
+              subtitle:
+                  const Text('Calculá la prueba Z y guardá los resultados'),
+              onTap: () {
+                Navigator.pop(ctx);
+                Navigator.pushNamed(context, '/level5');
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _playButton(BuildContext context, {bool expanded = false}) {
     final button = FilledButton(
       onPressed: () => Navigator.pushNamed(context, '/level1'),
@@ -263,50 +307,70 @@ class HomeDesktop extends StatelessWidget {
 
                     const SizedBox(height: 20),
 
-                    // Niveles
-                    const _H3('🎮 Niveles'),
+                    const _H3('🧑‍🍳 Yo / Presentación del juego'),
+                    const SizedBox(height: 8),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: const [
+                        Icon(Icons.restaurant_menu,
+                            size: 48, color: onAccent),
+                        SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            'Nido Mozzarella es un restaurante kawaii donde podés poner a prueba tus reflejos y luego analizar los datos generados.',
+                            softWrap: true,
+                          ),
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: 20),
+                    const _H3('📊 Datos del juego'),
                     const SizedBox(height: 10),
-                    // Tarjetas con accesos a cada nivel gamificado.
                     Wrap(
                       spacing: 14,
                       runSpacing: 14,
                       children: [
                         _LevelCard(
-                            title: 'Nivel 1',
-                            subtitle: '🍽️ Restaurante',
-                            icon: Icons.pets,
-                            onTap: () =>
-                                Navigator.pushNamed(context, '/level1')),
+                          title: 'EDA interactiva',
+                          subtitle: 'Explorá participación por queso',
+                          icon: Icons.bar_chart_rounded,
+                          onTap: () => Navigator.pushNamed(context, '/level2'),
+                        ),
                         _LevelCard(
-                            title: 'Nivel 2',
-                            subtitle: '📊 EDA',
-                            icon: Icons.bar_chart_rounded,
-                            onTap: () =>
-                                Navigator.pushNamed(context, '/level2')),
+                          title: 'Predicción ML',
+                          subtitle: 'Modelo online y aprendizaje',
+                          icon: Icons.auto_graph,
+                          onTap: () => Navigator.pushNamed(context, '/level4'),
+                        ),
                         _LevelCard(
-                            title: 'Nivel 3',
-                            subtitle: '📦 Inventario',
-                            icon: Icons.inventory_2_rounded,
-                            onTap: () =>
-                                Navigator.pushNamed(context, '/level3')),
+                          title: 'Dashboard & A/B',
+                          subtitle: 'Panel con insights y experimento',
+                          icon: Icons.space_dashboard_rounded,
+                          onTap: () => _openDashboardModal(context),
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: 20),
+                    const _H3('🎮 Jugar'),
+                    const SizedBox(height: 10),
+                    Wrap(
+                      spacing: 14,
+                      runSpacing: 14,
+                      children: [
                         _LevelCard(
-                            title: 'Nivel 4',
-                            subtitle: '🤖 Predicción ML',
-                            icon: Icons.auto_graph,
-                            onTap: () =>
-                                Navigator.pushNamed(context, '/level4')),
+                          title: 'Nido Mozzarella',
+                          subtitle: 'Atendé pedidos y sumá puntos',
+                          icon: Icons.restaurant_menu,
+                          onTap: () => Navigator.pushNamed(context, '/level1'),
+                        ),
                         _LevelCard(
-                            title: 'Nivel 5',
-                            subtitle: '🔀 A/B Test',
-                            icon: Icons.science,
-                            onTap: () =>
-                                Navigator.pushNamed(context, '/level5')),
-                        _LevelCard(
-                            title: 'Panel',
-                            subtitle: '📉 Dashboard',
-                            icon: Icons.space_dashboard_rounded,
-                            onTap: () =>
-                                Navigator.pushNamed(context, '/dashboard')),
+                          title: 'Inventario',
+                          subtitle: 'Gestioná y reponé quesos',
+                          icon: Icons.inventory_2_rounded,
+                          onTap: () => Navigator.pushNamed(context, '/level3'),
+                        ),
                       ],
                     ),
 

--- a/lib/models/inventory_item.dart
+++ b/lib/models/inventory_item.dart
@@ -11,18 +11,19 @@ class InventoryItem {
     required this.name,
     required this.stock,
     required this.expiry,
-    this.reorderPoint = 5,
+    this.reorderPoint = 30,
   });
 
   /// Construye desde CSV [id, nombre, stock_ignorado, YYYY-MM-DD].
-  /// Forzamos stock inicial = 10 (según requisitos de UX).
+  /// Forzamos stock inicial = 30 (según requisitos de UX).
   factory InventoryItem.fromCsv(List<dynamic> row) {
     return InventoryItem(
       id: int.tryParse(row[0].toString()) ?? 0,
       name: row[1].toString(),
-      // Arranca siempre con 10 unidades, ignorando el CSV
-      stock: 10,
+      // Arranca siempre con 30 unidades, ignorando el CSV
+      stock: 30,
       expiry: DateTime.tryParse(row[3].toString()) ?? DateTime.now().add(const Duration(days: 365)),
+      reorderPoint: 30,
     );
   }
 

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -22,32 +22,6 @@ class _Level5DashboardScreenState extends State<Level5DashboardScreen> {
   static const textDark = Color(0xFF6B4E16);
 
   @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      final app = context.read<AppState>();
-      final level = app.lastLevelCompleted;
-      if (level != null) {
-        showDialog<void>(
-          context: context,
-          builder: (context) => AlertDialog(
-            title: const Text('Nivel completado'),
-            content: Text('Completaste el Nivel $level. ¡Bien hecho!'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: const Text('Aceptar'),
-              ),
-            ],
-          ),
-        );
-        app.clearLastLevelCompleted();
-      }
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
     final app = context.watch<AppState>();
     final today = DateFormat('dd MMM yyyy', 'es_AR').format(DateTime.now());
@@ -462,7 +436,7 @@ class _PieCheese extends StatelessWidget {
         message: 'Sin datos aún — jugá un nivel para ver participación por queso.',
         labels: _kCheeseLabels,
         valueSuffix: '%',
-        height: 180,
+        height: 220,
       );
     }
 
@@ -472,7 +446,7 @@ class _PieCheese extends StatelessWidget {
         message: 'Sin datos aún — jugá un nivel para ver participación por queso.',
         labels: _kCheeseLabels,
         valueSuffix: '%',
-        height: 180,
+        height: 220,
       );
     }
 

--- a/lib/screens/level4_mlprediction_screen.dart
+++ b/lib/screens/level4_mlprediction_screen.dart
@@ -125,6 +125,8 @@ class _Level4MlPredictionScreenState extends State<Level4MlPredictionScreen> {
                   ctx,
                   '🧀 Aprendido: conversión con $quesoSugerido',
                   icon: Icons.check_circle,
+                  duration: const Duration(seconds: 2),
+                  margin: const EdgeInsets.only(left: 16, right: 16, bottom: 120),
                 );
               } else {
                 KawaiiToast.show(
@@ -133,6 +135,8 @@ class _Level4MlPredictionScreenState extends State<Level4MlPredictionScreen> {
                   color: Colors.orange,
                   icon: Icons.warning_amber_rounded,
                   success: false,
+                  duration: const Duration(seconds: 2),
+                  margin: const EdgeInsets.only(left: 16, right: 16, bottom: 120),
                 );
               }
             },
@@ -168,45 +172,50 @@ class _Level4MlPredictionScreenState extends State<Level4MlPredictionScreen> {
         ],
       ),
       body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text(
-                'Ajustá los sliders y tocá “Predecir”. El modelo sugiere qué queso ofrecer ahora.',
-                style: Theme.of(context).textTheme.bodyMedium,
-                softWrap: true,
-              ),
-              const SizedBox(height: 12),
-              if (isMobile) ...[
-                params,
-                const SizedBox(height: 12),
-                result,
-                reasonsButton,
-                const SizedBox(height: 12),
-                aprender,
-              ] else
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Expanded(child: params),
-                    const SizedBox(width: 16),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          result,
-                          reasonsButton,
-                          const SizedBox(height: 12),
-                          aprender,
-                        ],
-                      ),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 1100),
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'Ajustá los sliders y tocá “Predecir”. El modelo sugiere qué queso ofrecer ahora.',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    softWrap: true,
+                  ),
+                  const SizedBox(height: 12),
+                  if (isMobile) ...[
+                    params,
+                    const SizedBox(height: 12),
+                    result,
+                    reasonsButton,
+                    const SizedBox(height: 12),
+                    aprender,
+                  ] else
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(child: params),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              result,
+                              reasonsButton,
+                              const SizedBox(height: 12),
+                              aprender,
+                            ],
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-              const SizedBox(height: 120),
-            ],
+                  const SizedBox(height: 120),
+                ],
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/screens/level5_abtest_screen.dart
+++ b/lib/screens/level5_abtest_screen.dart
@@ -94,125 +94,130 @@ class _Level5AbTestScreenState extends State<Level5AbTestScreen> {
         ],
       ),
       body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
-          child: LayoutBuilder(
-            builder: (context, c) {
-              final isNarrow = c.maxWidth < 760;
-              final form = _buildPanels();
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    'Compará la tasa de conversión de Control (A) vs Tratamiento (B) con Z para dos proporciones (prueba bilateral).',
-                    style: theme.textTheme.bodyMedium,
-                    softWrap: true,
-                  ),
-                  const SizedBox(height: 12),
-                  const _AbTestExplanationTile(),
-                  const SizedBox(height: 16),
-                  if (isNarrow) ...[
-                    form[0],
-                    const SizedBox(height: 12),
-                    form[1],
-                  ] else
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Expanded(child: form[0]),
-                        const SizedBox(width: 16),
-                        Expanded(child: form[1]),
-                      ],
-                    ),
-                  const SizedBox(height: 16),
-                  Align(
-                    child: ElevatedButton(
-                      onPressed: _onCalculate,
-                      style: ElevatedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 16),
-                        minimumSize: const Size.fromHeight(56),
-                        backgroundColor: const Color(0xFFFFD54F),
-                        foregroundColor: Colors.brown,
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 1100),
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: LayoutBuilder(
+                builder: (context, c) {
+                  final isNarrow = c.maxWidth < 760;
+                  final form = _buildPanels();
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        'Compará la tasa de conversión de Control (A) vs Tratamiento (B) con Z para dos proporciones (prueba bilateral).',
+                        style: theme.textTheme.bodyMedium,
+                        softWrap: true,
                       ),
-                      child: const Text('Calcular Z y p-valor'),
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  Card(
-                    elevation: 0,
-                    color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: .5),
-                    child: Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            _summary,
-                            style: theme.textTheme.titleMedium,
-                            softWrap: true,
-                          ),
-                          if (_pTwo != null) ...[
-                            const SizedBox(height: 10),
-                            Text(
-                              'Detalle: pA=${((_pA ?? 0) * 100).toStringAsFixed(1)}% · pB=${((_pB ?? 0) * 100).toStringAsFixed(1)}% · Δ=${((_diff ?? 0) * 100).toStringAsFixed(1)}% · Lift=${_lift == null ? '—' : '${((_lift ?? 0) * 100).toStringAsFixed(1)}%'} · IC95%=[${((_ciL ?? 0) * 100).toStringAsFixed(1)}%, ${((_ciH ?? 0) * 100).toStringAsFixed(1)}%] · p=${(_pTwo ?? 0).toStringAsFixed(4)}',
-                              softWrap: true,
-                            ),
-                            const SizedBox(height: 8),
-                            const Text(
-                              'Tip: p < 0.05 ⇒ diferencia significativa (bilateral, α = 0.05).',
-                              style: TextStyle(fontSize: 13, fontStyle: FontStyle.italic),
-                            ),
+                      const SizedBox(height: 12),
+                      const _AbTestExplanationTile(),
+                      const SizedBox(height: 16),
+                      if (isNarrow) ...[
+                        form[0],
+                        const SizedBox(height: 12),
+                        form[1],
+                      ] else
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Expanded(child: form[0]),
+                            const SizedBox(width: 16),
+                            Expanded(child: form[1]),
                           ],
-                        ],
-                      ),
-                    ),
-                  ),
-                  if (_pTwo != null) ...[
-                    const SizedBox(height: 12),
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: ElevatedButton.icon(
-                        onPressed: () async {
-                          final result = {
-                            'nA': _cNController.text,
-                            'cA': _cXController.text,
-                            'pA': _pA?.toStringAsFixed(4),
-                            'nB': _tNController.text,
-                            'cB': _tXController.text,
-                            'pB': _pB?.toStringAsFixed(4),
-                            'diff': _diff?.toStringAsFixed(4),
-                            'lift': _lift == null ? '—' : '${(_lift! * 100).toStringAsFixed(1)}%',
-                            'z': _z?.toStringAsFixed(3),
-                            'p': _pTwo?.toStringAsFixed(4),
-                            'ci': _ciL == null || _ciH == null
-                                ? '—'
-                                : '[${(_ciL! * 100).toStringAsFixed(1)}%, ${(_ciH!*100).toStringAsFixed(1)}%]',
-                            'sig': _sig ? 'Sí' : 'No',
-                            'alpha': '0.05',
-                            'note': 'Resultado guardado desde Nivel A/B',
-                          };
-                          final ab = context.read<ABResultState>();
-                          await ab.save(result);
-                          if (!context.mounted) return;
-                          context.read<AppState>().setLevelCompleted(5);
-                          Navigator.pushNamed(context, '/dashboard');
-                        },
-                        icon: const Icon(Icons.arrow_forward),
-                        label: const Text('Ir al Dashboard'),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xFFFFE082),
-                          foregroundColor: Colors.brown,
-                          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
-                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
+                      const SizedBox(height: 16),
+                      Align(
+                        child: ElevatedButton(
+                          onPressed: _onCalculate,
+                          style: ElevatedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 16),
+                            minimumSize: const Size.fromHeight(56),
+                            backgroundColor: const Color(0xFFFFD54F),
+                            foregroundColor: Colors.brown,
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                          ),
+                          child: const Text('Calcular Z y p-valor'),
                         ),
                       ),
-                    ),
-                  ],
-                  const SizedBox(height: 120),
-                ],
-              );
-            },
+                      const SizedBox(height: 16),
+                      Card(
+                        elevation: 0,
+                        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: .5),
+                        child: Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                _summary,
+                                style: theme.textTheme.titleMedium,
+                                softWrap: true,
+                              ),
+                              if (_pTwo != null) ...[
+                                const SizedBox(height: 10),
+                                Text(
+                                  'Detalle: pA=${((_pA ?? 0) * 100).toStringAsFixed(1)}% · pB=${((_pB ?? 0) * 100).toStringAsFixed(1)}% · Δ=${((_diff ?? 0) * 100).toStringAsFixed(1)}% · Lift=${_lift == null ? '—' : '${((_lift ?? 0) * 100).toStringAsFixed(1)}%'} · IC95%=[${((_ciL ?? 0) * 100).toStringAsFixed(1)}%, ${((_ciH ?? 0) * 100).toStringAsFixed(1)}%] · p=${(_pTwo ?? 0).toStringAsFixed(4)}',
+                                  softWrap: true,
+                                ),
+                                const SizedBox(height: 8),
+                                const Text(
+                                  'Tip: p < 0.05 ⇒ diferencia significativa (bilateral, α = 0.05).',
+                                  style: TextStyle(fontSize: 13, fontStyle: FontStyle.italic),
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      ),
+                      if (_pTwo != null) ...[
+                        const SizedBox(height: 12),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: ElevatedButton.icon(
+                            onPressed: () async {
+                              final result = {
+                                'nA': _cNController.text,
+                                'cA': _cXController.text,
+                                'pA': _pA?.toStringAsFixed(4),
+                                'nB': _tNController.text,
+                                'cB': _tXController.text,
+                                'pB': _pB?.toStringAsFixed(4),
+                                'diff': _diff?.toStringAsFixed(4),
+                                'lift': _lift == null ? '—' : '${(_lift! * 100).toStringAsFixed(1)}%',
+                                'z': _z?.toStringAsFixed(3),
+                                'p': _pTwo?.toStringAsFixed(4),
+                                'ci': _ciL == null || _ciH == null
+                                    ? '—'
+                                    : '[${(_ciL! * 100).toStringAsFixed(1)}%, ${(_ciH!*100).toStringAsFixed(1)}%]',
+                                'sig': _sig ? 'Sí' : 'No',
+                                'alpha': '0.05',
+                                'note': 'Resultado guardado desde Nivel A/B',
+                              };
+                              final ab = context.read<ABResultState>();
+                              await ab.save(result);
+                              if (!context.mounted) return;
+                              context.read<AppState>().setLevelCompleted(5);
+                              Navigator.pushNamed(context, '/dashboard');
+                            },
+                            icon: const Icon(Icons.arrow_forward),
+                            label: const Text('Ir al Dashboard'),
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: const Color(0xFFFFE082),
+                              foregroundColor: Colors.brown,
+                              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                            ),
+                          ),
+                        ),
+                      ],
+                      const SizedBox(height: 120),
+                    ],
+                  );
+                },
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/services/data_service.dart
+++ b/lib/services/data_service.dart
@@ -69,7 +69,7 @@ class DataService {
   }
 
   /// Carga inventario con ID, nombre y fecha de caducidad (YYYY-MM-DD).
-  /// El stock inicial se fija en 10 al parsear cada fila (ver InventoryItem.fromCsv).
+  /// El stock inicial se fija en 30 al parsear cada fila (ver InventoryItem.fromCsv).
   static Future<List<InventoryItem>> loadInventory() async {
     // Si existe CSV, lo ignoramos: inventario semilla fijo con 6 quesos
     final now = DateTime.now();
@@ -77,7 +77,13 @@ class DataService {
     final out = <InventoryItem>[];
     var id = 1;
     for (final c in kCheeses) {
-      out.add(InventoryItem(id: id++, name: c.nombre, stock: 10, expiry: expiry));
+      out.add(InventoryItem(
+        id: id++,
+        name: c.nombre,
+        stock: 30,
+        expiry: expiry,
+        reorderPoint: 30,
+      ));
     }
     return out;
   }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -65,10 +65,10 @@ class AppState extends ChangeNotifier {
 
   void restockFull(String name) {
     final item = inventory[name];
-    if (item == null || item.stock >= maxStock) return;
-
-    inventory[name] = item.copyWith(stock: maxStock);
-    notifyListeners();
+    if (item == null) return;
+    final diff = maxStock - item.stock;
+    if (diff <= 0) return;
+    restock(name, diff);
   }
 
   /// Intenta servir un queso. Devuelve true si se pudo.

--- a/lib/utils/kawaii_toast.dart
+++ b/lib/utils/kawaii_toast.dart
@@ -10,48 +10,147 @@ class KawaiiToast {
     Color color = const Color(0xFF34A853),
     Duration duration = const Duration(milliseconds: 1600),
     bool success = true,
+    Alignment alignment = Alignment.bottomCenter,
+    EdgeInsets? margin,
   }) {
     final overlay = Overlay.maybeOf(context);
     if (overlay == null) return;
 
-    final entry = OverlayEntry(
-      builder: (ctx) => SafeArea(
+    final media = MediaQuery.maybeOf(context);
+    final safeBottom = media?.viewPadding.bottom ?? 0;
+    final resolvedMargin = margin ??
+        EdgeInsets.only(left: 16, right: 16, bottom: 16 + safeBottom);
+
+    late final OverlayEntry entry;
+    entry = OverlayEntry(
+      builder: (ctx) => _ToastOverlay(
+        text: text,
+        icon: icon,
+        color: color,
+        duration: duration,
+        alignment: alignment,
+        margin: resolvedMargin,
+        onDismissed: () {
+          if (entry.mounted) entry.remove();
+        },
+      ),
+    );
+
+    overlay.insert(entry);
+    sound.playPopupSound(success: success);
+  }
+}
+
+class _ToastOverlay extends StatefulWidget {
+  final String text;
+  final IconData icon;
+  final Color color;
+  final Duration duration;
+  final Alignment alignment;
+  final EdgeInsets margin;
+  final VoidCallback onDismissed;
+
+  const _ToastOverlay({
+    required this.text,
+    required this.icon,
+    required this.color,
+    required this.duration,
+    required this.alignment,
+    required this.margin,
+    required this.onDismissed,
+  });
+
+  @override
+  State<_ToastOverlay> createState() => _ToastOverlayState();
+}
+
+class _ToastOverlayState extends State<_ToastOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 220),
+    reverseDuration: const Duration(milliseconds: 180),
+  );
+  late final Animation<Offset> _slide = Tween<Offset>(
+    begin: const Offset(0, 0.2),
+    end: Offset.zero,
+  ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic));
+  late final Animation<double> _fade = CurvedAnimation(
+    parent: _controller,
+    curve: Curves.easeOutCubic,
+  );
+  bool _removed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.forward();
+    Future.delayed(widget.duration, () async {
+      if (!mounted) return;
+      await _controller.reverse();
+      if (mounted) _close();
+    });
+  }
+
+  void _close() {
+    if (_removed) return;
+    _removed = true;
+    widget.onDismissed();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      ignoring: true,
+      child: SafeArea(
         child: Align(
-          alignment: Alignment.bottomCenter,
+          alignment: widget.alignment,
           child: Padding(
-            padding: const EdgeInsets.only(bottom: 16),
-            child: Material(
-              color: Colors.transparent,
-              child: Container(
-                constraints: const BoxConstraints(maxWidth: 520),
-                margin: const EdgeInsets.symmetric(horizontal: 16),
-                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-                decoration: BoxDecoration(
-                  color: color,
-                  borderRadius: BorderRadius.circular(12),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: .12),
-                      blurRadius: 10,
-                      offset: const Offset(0, 4),
-                    ),
-                  ],
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(icon, color: Colors.white),
-                    const SizedBox(width: 8),
-                    Flexible(
-                      child: Text(
-                        text,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.w700,
+            padding: widget.margin,
+            child: SlideTransition(
+              position: _slide,
+              child: FadeTransition(
+                opacity: _fade,
+                child: Material(
+                  color: Colors.transparent,
+                  child: Container(
+                    constraints: const BoxConstraints(maxWidth: 520),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                    decoration: BoxDecoration(
+                      color: widget.color,
+                      borderRadius: BorderRadius.circular(12),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: .12),
+                          blurRadius: 10,
+                          offset: const Offset(0, 4),
                         ),
-                      ),
+                      ],
                     ),
-                  ],
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(widget.icon, color: Colors.white),
+                        const SizedBox(width: 8),
+                        Flexible(
+                          child: Text(
+                            widget.text,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
                 ),
               ),
             ),
@@ -59,12 +158,6 @@ class KawaiiToast {
         ),
       ),
     );
-
-    overlay.insert(entry);
-    sound.playPopupSound(success: success);
-    Future.delayed(duration, () {
-      if (entry.mounted) entry.remove();
-    });
   }
 }
 

--- a/lib/widgets/inventory_mouse.dart
+++ b/lib/widgets/inventory_mouse.dart
@@ -102,7 +102,7 @@ class _InventoryMouseState extends State<InventoryMouse>
                   const Text('Ratón de Depósito', style: TextStyle(fontWeight: FontWeight.w700, color: Color(0xFF5B4636))),
                   Text(
                     widget.items.any((e) => e.stock <= widget.lowThreshold)
-                        ? '¡Atención! Stock crítico (<10)'
+                        ? '¡Atención! Stock crítico (0–9)'
                         : 'Todo en orden 🧀',
                     style: const TextStyle(color: Color(0xFF5B4636)),
                   ),


### PR DESCRIPTION
## Summary
- raise inventory defaults to 30 units and refresh the level 3 restock UX with animated toasts and a full-fill control
- tighten level 1 gameplay flow with stock-aware toasts, responsive stat tiles, and navigation that leads back to inventory
- reorganize the home and dashboard sections while restoring the original favicon/PWA assets to resolve the binary compatibility issue

## Testing
- flutter clean *(fails: `flutter` command not available in container)*
- flutter pub get *(fails: `flutter` command not available in container)*
- flutter analyze *(fails: `flutter` command not available in container)*
- flutter build web --release *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ced8e870348332ac2d517840b3e961