### PR TITLE
Fix deprecated Material color usage

### DIFF
--- a/lib/screens/level1_game_screen.dart
+++ b/lib/screens/level1_game_screen.dart
@@ -562,7 +562,7 @@ class _Level1GameScreenState extends State<Level1GameScreen>
                       ? Theme.of(context).colorScheme.primary
                       : Theme.of(context)
                           .colorScheme
-                          .surfaceVariant
+                          .surfaceContainerHighest
                           .withValues(alpha: 0.8),
                   foregroundColor: canProceed
                       ? Theme.of(context).colorScheme.onPrimary


### PR DESCRIPTION
## Summary
- replace the deprecated colorScheme.surfaceVariant usage on the level 1 game screen with surfaceContainerHighest

## Testing
- flutter analyze *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cef40c1584833285c089ccbd76277c