### PR TITLE
feat: restore ratón hero asset and reorder home sections

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -42,73 +42,93 @@ class HomeDesktop extends StatelessWidget {
     );
     return expanded ? SizedBox(width: double.infinity, child: btn) : btn;
   }
-  Widget _buildAboutSection(BuildContext context, bool isMobile) {
-    return Flex(
-      direction: isMobile ? Axis.vertical : Axis.horizontal,
+  Widget _buildAboutSection(bool isMobile) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _HomeCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _H3('✨ Sobre mí'),
+              SizedBox(height: 8),
+              Text(
+                'Estudiante de Negocios Digitales (UADE). Me formé en análisis de datos, marketing y desarrollo web. '
+                'Capacitaciones en Python, Django, React.js y SQL. Combino tecnología + eficiencia operativa + enfoque estratégico '
+                'para crear soluciones simples y efectivas.',
+              ),
+              SizedBox(height: 12),
+              _Dot('Análisis de datos (Python, SQL, EDA)'),
+              _Dot('Desarrollo web (Django, React.js)'),
+              _Dot('Orientación a resultados + mejora de procesos.'),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        _buildResponsiveCardsRow(
+          isMobile: isMobile,
+          cards: const [
+            _HomeCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _H3('🛠️ Skills + Stack'),
+                  SizedBox(height: 8),
+                  _Chips([
+                    '🐍 Python',
+                    '🗄️ SQL',
+                    '📊 EDA',
+                    '⚛️ React.js',
+                    '🎨 Django',
+                    '🤖 scikit-learn',
+                    '📈 Dashboards',
+                    '📱 Flutter (UI)',
+                    '🔗 Git',
+                  ]),
+                ],
+              ),
+            ),
+            _HomeCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _H3('🎓 Educación y cursos'),
+                  SizedBox(height: 8),
+                  _Chips([
+                    '🎓 UADE — Lic. en Negocios Digitales (en curso)',
+                    '🎓 React.js — Educación IT (2024)',
+                    '🎓 Python Avanzado — Educación IT (2024)',
+                    '🎓 Bases de Datos y SQL — Educación IT (2023)',
+                    '🎓 Marketing Digital — CoderHouse (2024)',
+                  ]),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildResponsiveCardsRow({required bool isMobile, required List<Widget> cards}) {
+    if (isMobile) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (var i = 0; i < cards.length; i++) ...[
+            cards[i],
+            if (i != cards.length - 1) const SizedBox(height: 16),
+          ],
+        ],
+      );
+    }
+    return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Expanded(
-          child: _HomeCard(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: const [
-                _H3('✨ Sobre mí'),
-                SizedBox(height: 8),
-                Text(
-                  'Estudiante de Negocios Digitales (UADE). Me formé en análisis de datos, marketing y desarrollo web. '
-                  'Capacitaciones en Python, Django, React.js y SQL. Combino tecnología + eficiencia operativa + enfoque estratégico '
-                  'para crear soluciones simples y efectivas.',
-                ),
-                SizedBox(height: 12),
-                _Dot('Análisis de datos (Python, SQL, EDA)'),
-                _Dot('Desarrollo web (Django, React.js)'),
-                _Dot('Orientación a resultados + mejora de procesos.'),
-              ],
-            ),
-          ),
-        ),
-        SizedBox(width: isMobile ? 0 : 16, height: isMobile ? 16 : 0),
-        Expanded(
-          child: _HomeCard(
-            child: const Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _H3('🛠️ Skills + Stack'),
-                SizedBox(height: 8),
-                _Chips([
-                  '🐍 Python',
-                  '🗄️ SQL',
-                  '📊 EDA',
-                  '⚛️ React.js',
-                  '🎨 Django',
-                  '🤖 scikit-learn',
-                  '📈 Dashboards',
-                  '📱 Flutter (UI)',
-                  '🔗 Git',
-                ]),
-              ],
-            ),
-          ),
-        ),
-        SizedBox(width: isMobile ? 0 : 16, height: isMobile ? 16 : 0),
-        Expanded(
-          child: _HomeCard(
-            child: const Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _H3('🎓 Educación y cursos'),
-                SizedBox(height: 8),
-                _Chips([
-                  '🎓 UADE — Lic. en Negocios Digitales (en curso)',
-                  '🎓 React.js — Educación IT (2024)',
-                  '🎓 Python Avanzado — Educación IT (2024)',
-                  '🎓 Bases de Datos y SQL — Educación IT (2023)',
-                  '🎓 Marketing Digital — CoderHouse (2024)',
-                ]),
-              ],
-            ),
-          ),
-        ),
+        for (var i = 0; i < cards.length; i++) ...[
+          Expanded(child: cards[i]),
+          if (i != cards.length - 1) const SizedBox(width: 16),
+        ],
       ],
     );
   }
@@ -137,7 +157,29 @@ class HomeDesktop extends StatelessWidget {
                       _buildHeroSection(context, isMobile),
                       const SizedBox(height: 16),
 
-                      // === JUGAR (arriba) ===
+                      // Sobre mí + Skills + Educación
+                      _buildAboutSection(isMobile),
+                      const SizedBox(height: 24),
+
+                      // CTA grande “Jugar ahora”
+                      _HomeCard(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const _H3('🎮 Jugar ahora'),
+                            const SizedBox(height: 8),
+                            const Text(
+                              'Entrá a “Nido Mozzarella” y atendé pedidos en un juego kawaii. '
+                              'Cada partida genera datos reales para el análisis y el dashboard.',
+                            ),
+                            const SizedBox(height: 16),
+                            _playButton(context, expanded: true),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+
+                      // Sección Jugar (Nido Mozzarella, Inventario)
                       const _H3('🕹️ Jugar'),
                       const SizedBox(height: 10),
                       _CardsSection(
@@ -159,25 +201,7 @@ class HomeDesktop extends StatelessWidget {
                       ),
                       const SizedBox(height: 24),
 
-                      // CTA grande “Jugar ahora”
-                      _HomeCard(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const _H3('🎮 Jugar ahora'),
-                            const SizedBox(height: 8),
-                            const Text(
-                              'Entrá a “Nido Mozzarella” y atendé pedidos en un juego kawaii. '
-                              'Cada partida genera datos reales para el análisis y el dashboard.',
-                            ),
-                            const SizedBox(height: 16),
-                            _playButton(context, expanded: true),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(height: 24),
-
-                      // === DATOS DEL JUEGO (abajo) ===
+                      // Sección Datos del juego (EDA, ML, Dashboard)
                       const _H3('📊 Datos del juego'),
                       const SizedBox(height: 10),
                       _CardsSection(
@@ -203,10 +227,6 @@ class HomeDesktop extends StatelessWidget {
                           ),
                         ],
                       ),
-                      const SizedBox(height: 24),
-
-                      // Sobre mí
-                      _buildAboutSection(context, isMobile),
                       const SizedBox(height: 24),
 
                       // Contacto
@@ -281,7 +301,16 @@ class HomeDesktop extends StatelessWidget {
         boxShadow: [BoxShadow(color: Colors.black.withValues(alpha: 0.05), blurRadius: 8, offset: const Offset(0, 4))],
       ),
       alignment: Alignment.center,
-      child: const Text('🧀', style: TextStyle(fontSize: 68)), // emoji, sin asset binario
+      child: Image.asset(
+        'assets/img/raton_menu.png',
+        width: 110,
+        fit: BoxFit.contain,
+        errorBuilder: (context, error, stackTrace) => const Icon(
+          Icons.image_not_supported_outlined,
+          size: 56,
+          color: onAccent,
+        ),
+      ),
     );
 
     final children = isMobile


### PR DESCRIPTION
## Summary
- restore the ratón hero image with an error fallback while keeping the María Luján Massironi greeting
- move the “Sobre mí”, “🛠️ Skills + Stack” and “🎓 Educación y cursos” cards directly under the hero and keep the requested order for the remaining sections
- add a helper to reuse responsive card rows so the layout stays consistent on mobile and desktop

## Testing
- `flutter analyze` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0cf0e0bc8332bf20c17e64ef2df1