### PR TITLE
fix: clean analyzer warnings in eda, ml and popup

### DIFF
--- a/lib/screens/level2_eda_screen.dart
+++ b/lib/screens/level2_eda_screen.dart
@@ -402,18 +402,6 @@ class _ParticipacionCard extends StatelessWidget {
       }
     }
 
-    final cardDecoration = BoxDecoration(
-      color: theme.colorScheme.surface,
-      borderRadius: BorderRadius.circular(16),
-      boxShadow: [
-        BoxShadow(
-          color: Colors.black.withValues(alpha: 0.05),
-          blurRadius: 10,
-          offset: const Offset(0, 4),
-        ),
-      ],
-    );
-
     return KawaiiCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/level4_mlprediction_screen.dart
+++ b/lib/screens/level4_mlprediction_screen.dart
@@ -376,52 +376,51 @@ class _ResultadoCard extends StatelessWidget {
       duration: const Duration(milliseconds: 200),
       child: KawaiiCard(
         child: hasResult
-              ? Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Resultado de la predicción',
-                      style: Theme.of(context)
-                          .textTheme
-                          .labelLarge
-                          ?.copyWith(fontWeight: FontWeight.w700),
-                    ),
-                    const SizedBox(height: 12),
-                    Text(
-                      'Probabilidad de conversión: ${(probPredicha! * 100).toStringAsFixed(1)} %',
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      sugerencia ?? '',
-                      style: Theme.of(context).textTheme.bodyMedium,
-                      softWrap: true,
-                    ),
-                    const SizedBox(height: 16),
-                    const _HowCalculatedTile(),
-                  ],
-                )
-              : Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Listo para predecir',
-                      style: Theme.of(context)
-                          .textTheme
-                          .labelLarge
-                          ?.copyWith(fontWeight: FontWeight.w700),
-                    ),
-                    const SizedBox(height: 8),
-                    const Text(
-                      'Necesito feedback para aprender: ajustá los parámetros y tocá “Predecir” '
-                      'para estimar la probabilidad de acierto del próximo pedido.',
-                      softWrap: true,
-                    ),
-                    const SizedBox(height: 16),
-                    const _HowCalculatedTile(),
-                  ],
-                ),
-        ),
+            ? Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Resultado de la predicción',
+                    style: Theme.of(context)
+                        .textTheme
+                        .labelLarge
+                        ?.copyWith(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'Probabilidad de conversión: ${(probPredicha! * 100).toStringAsFixed(1)} %',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    sugerencia ?? '',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    softWrap: true,
+                  ),
+                  const SizedBox(height: 16),
+                  const _HowCalculatedTile(),
+                ],
+              )
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Listo para predecir',
+                    style: Theme.of(context)
+                        .textTheme
+                        .labelLarge
+                        ?.copyWith(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    'Necesito feedback para aprender: ajustá los parámetros y tocá “Predecir” '
+                    'para estimar la probabilidad de acierto del próximo pedido.',
+                    softWrap: true,
+                  ),
+                  const SizedBox(height: 16),
+                  const _HowCalculatedTile(),
+                ],
+              ),
       ),
     );
   }
@@ -479,74 +478,73 @@ class _AprenderCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return KawaiiCard(
       child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              texto,
-              style: Theme.of(context)
-                  .textTheme
-                  .labelLarge
-                  ?.copyWith(fontWeight: FontWeight.w700),
-            ),
-            const SizedBox(height: 12),
-            LayoutBuilder(
-              builder: (context, constraints) {
-                Widget buildSuccess({double? width}) => SizedBox(
-                      width: width,
-                      child: ElevatedButton.icon(
-                        onPressed: () => onAprender(true),
-                        icon: const Icon(Icons.check_circle_outline),
-                        label: const Text('Convirtió'),
-                        style: ElevatedButton.styleFrom(
-                          minimumSize: const Size(140, 48),
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 20, vertical: 14),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            texto,
+            style: Theme.of(context)
+                .textTheme
+                .labelLarge
+                ?.copyWith(fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 12),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              Widget buildSuccess({double? width}) => SizedBox(
+                    width: width,
+                    child: ElevatedButton.icon(
+                      onPressed: () => onAprender(true),
+                      icon: const Icon(Icons.check_circle_outline),
+                      label: const Text('Convirtió'),
+                      style: ElevatedButton.styleFrom(
+                        minimumSize: const Size(140, 48),
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
                         ),
                       ),
-                    );
-                Widget buildFail({double? width}) => SizedBox(
-                      width: width,
-                      child: OutlinedButton.icon(
-                        onPressed: () => onAprender(false),
-                        icon: const Icon(Icons.cancel_outlined),
-                        label: const Text('No convirtió'),
-                        style: OutlinedButton.styleFrom(
-                          minimumSize: const Size(140, 48),
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 20, vertical: 14),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                        ),
-                      ),
-                    );
-
-                if (constraints.maxWidth < 360) {
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      buildSuccess(width: double.infinity),
-                      const SizedBox(height: 8),
-                      buildFail(width: double.infinity),
-                    ],
+                    ),
                   );
-                }
+              Widget buildFail({double? width}) => SizedBox(
+                    width: width,
+                    child: OutlinedButton.icon(
+                      onPressed: () => onAprender(false),
+                      icon: const Icon(Icons.cancel_outlined),
+                      label: const Text('No convirtió'),
+                      style: OutlinedButton.styleFrom(
+                        minimumSize: const Size(140, 48),
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                    ),
+                  );
 
-                return Wrap(
-                  spacing: 12,
-                  runSpacing: 8,
+              if (constraints.maxWidth < 360) {
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    buildSuccess(width: 180),
-                    buildFail(width: 180),
+                    buildSuccess(width: double.infinity),
+                    const SizedBox(height: 8),
+                    buildFail(width: double.infinity),
                   ],
                 );
-              },
-            ),
-          ],
-        ),
+              }
+
+              return Wrap(
+                spacing: 12,
+                runSpacing: 8,
+                children: [
+                  buildSuccess(width: 180),
+                  buildFail(width: 180),
+                ],
+              );
+            },
+          ),
+        ],
       ),
     );
   }

--- a/lib/utils/popup.dart
+++ b/lib/utils/popup.dart
@@ -104,7 +104,7 @@ class Popup {
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(title, style: Theme.of(context).textTheme.titleMedium),
-                              if (message != null && message.isNotEmpty) ...[
+                              if (message?.isNotEmpty ?? false) ...[
                                 const SizedBox(height: 4),
                                 Text(message, style: Theme.of(context).textTheme.bodyMedium),
                               ],


### PR DESCRIPTION
## Summary
- remove the unused card decoration from the EDA participation card
- normalize the ML prediction result and feedback widgets to remove stray tokens
- simplify the popup message guard to avoid redundant null comparisons

## Testing
- Not run (flutter is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf43237e348332bdf73a3f367d62fa